### PR TITLE
print EACCES for user ease

### DIFF
--- a/opensockets.c
+++ b/opensockets.c
@@ -131,6 +131,9 @@ static void process_pid(pid_t pid) {
 	struct dirent *dp;
 	if (!d) {
 		DEBUG("failed to open %s: %s\n", procdir, strerror(errno));
+		if (errno == EACCES)
+			fprintf(stderr, "failed to open %s: %s\n", procdir,
+			    strerror(errno));
 		return;
 	}
 	while ((dp = readdir(d))) {


### PR DESCRIPTION
when run as a normal user, it wouldn't be uncommon for `opensockets` to return nothing... this way the user will know it's because of permissions, and not a box with no sockets
